### PR TITLE
Suppressing error messages

### DIFF
--- a/_templates/global/Page.html
+++ b/_templates/global/Page.html
@@ -2,6 +2,11 @@
 {% load otree static %}
 
 {% block global_styles  %}
+<style>
+.otree-form-errors {
+    display: none;
+}
+</style>
 {% endblock %}
 
 {% block global_scripts  %}


### PR DESCRIPTION
This hacks the style for pages to hide the red error box on validation errors - they are still generated but not displayed by the browser.